### PR TITLE
Fix for regexes with interpolated and literal parts

### DIFF
--- a/lib/sorcerer/resource.rb
+++ b/lib/sorcerer/resource.rb
@@ -284,6 +284,7 @@ module Sorcerer
     SPACE = lambda { |sexp| emit(" ") }
     PASS1 = lambda { |sexp| resource(sexp[1]) }
     PASS2 = lambda { |sexp| resource(sexp[2]) }
+    PASSBOTH = lambda { |sexp| resource(sexp[1]); resource(sexp[2]) }
     EMIT1 = lambda { |sexp| emit(sexp[1]) }
 
     # Earlier versions of ripper miss array node for words, see
@@ -649,14 +650,8 @@ module Sorcerer
         emit(" = ")
         resource(sexp[2])
       },
-      :method_add_arg => lambda { |sexp|
-        resource(sexp[1])
-        resource(sexp[2])
-      },
-      :method_add_block => lambda { |sexp|
-        resource(sexp[1])
-        resource(sexp[2])
-      },
+      :method_add_arg => PASSBOTH,
+      :method_add_block => PASSBOTH,
       :mlhs_add => lambda { |sexp|
         resource(sexp[1])
         emit(", ") unless sexp[1] == [:mlhs_new]
@@ -728,13 +723,14 @@ module Sorcerer
       :redo => lambda { |sexp|
         emit("redo")
       },
-      :regexp_add => PASS2,
+      :regexp_add => PASSBOTH,
       :regexp_literal => lambda { |sexp|
         delims = determine_regexp_delimiters(sexp[2])
         emit(delims[0])
         resource(sexp[1])
         emit(delims[1])
       },
+      :regexp_new => NOOP,
       :rescue => lambda { |sexp|
         outdent do emit("rescue") end
         if sexp[1]                # Exception list
@@ -788,10 +784,7 @@ module Sorcerer
         resource(sexp[2]) if sexp[2]
       },
       :stmts_new => NOOP,
-      :string_add => lambda { |sexp|
-        resource(sexp[1])
-        resource(sexp[2])
-      },
+      :string_add => PASSBOTH,
       :string_concat => lambda { |sexp|
         resource(sexp[1])
         emit(" ")
@@ -901,10 +894,7 @@ module Sorcerer
         words("W", sexp)
       },
       :words_new => NOOP,
-      :xstring_add => lambda { |sexp|
-        resource(sexp[1])
-        resource(sexp[2])
-      },
+      :xstring_add => PASSBOTH,
       :xstring_literal => lambda { |sexp|
         emit('"')
         resource(sexp[1])

--- a/test/sorcerer/resource_test.rb
+++ b/test/sorcerer/resource_test.rb
@@ -276,6 +276,7 @@ class ResourceTest < Test::Unit::TestCase
     assert_resource "/[a-z]/"
     assert_resource "/\[a-z\]/"
     assert_resource '/#{name}/'
+    assert_resource '/before #{name} after/'
   end
 
   def test_can_source_regular_expressions_with_alternate_delimiters


### PR DESCRIPTION
Previously regexes would only retain the the last "part". For example `/a #{b} c/` would emit `/ c/`...
